### PR TITLE
Add Antora base image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,6 +50,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Build antora base image
+        uses: docker/build-push-action@68d0dc20df34f84bca5214ce60a32e2d589dbaf2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.base
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/vshn/antora-base:latest
+
       - name: Build and push Docker image
         uses: docker/build-push-action@68d0dc20df34f84bca5214ce60a32e2d589dbaf2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/antora/antora:3.1.4
+FROM vshn/antora-base:latest
 
 # Required by the CI/CD pipeline in GitLab
 RUN apk update && apk add make git yq jq

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,32 @@
+# Source https://gitlab.com/antora/docker-antora/-/blob/main/Dockerfile
+
+FROM node:16-alpine
+
+LABEL org.opencontainers.image.source="https://gitlab.com/antora/docker-antora"
+
+ENV NODE_PATH /usr/local/share/.config/yarn/global/node_modules
+
+RUN apk --no-cache add curl findutils jq \
+    && yarn global add --ignore-optional --silent @antora/cli@latest @antora/site-generator-default@latest \
+    && yarn global add --ignore-optional --silent $(grep -o '^isomorphic-git@[^:]*' `yarn global dir`/yarn.lock) \
+    && rm -rf $(yarn cache dir)/* \
+    && find $(yarn global dir)/node_modules/`[ -d $(yarn global dir)/node_modules/asciidoctor.js ] && echo asciidoctor.js || echo @asciidoctor/core`/dist -mindepth 1 -maxdepth 1 -not -name node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/dist -mindepth 1 -maxdepth 1 -not -name cjs -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/lib -mindepth 1 -maxdepth 1 -not -name index.js -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/dist/[^/]+' -not -name for-node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/http/[^/]+' -not -name node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -maxdepth 1 -type f -not -name cli.js -not -regex '.+\.\(cjs\|json\|md\)' -exec rm -f {} \; \
+    && rm -rf $(yarn global dir)/node_modules/js-yaml/dist \
+    && rm -rf $(yarn global dir)/node_modules/json5/dist \
+    && rm -rf $(yarn global dir)/node_modules/moment/min \
+    && rm -rf $(yarn global dir)/node_modules/moment/src \
+    && rm -rf $(yarn global dir)/node_modules/source-map/dist \
+    && rm -rf /tmp/*
+
+WORKDIR /antora
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["antora"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# source: https://gitlab.com/antora/docker-antora/-/blob/main/docker-entrypoint.sh
+
+# abort script if a command fails
+set -e
+
+# prepend antora if command is not detected
+if [ $# -eq 0 ] || [ "${1:0:1}" == '-' ] || [ -z "$(command -v "$1")" ] || [ -d "$(command -v "$1")" ] || [ ! -x "$(command -v "$1")" ]; then
+  set -- antora "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The Antora base image is currently not available as x86. So we need to build it ourselves to get a fully working arm image for vshn/antora and vshn/antora-preview.